### PR TITLE
add more styles/colors + background colors

### DIFF
--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -47,7 +47,7 @@ Used to output a simple list of headings in a structured form.
 
 ### Style
 <div class="grid" markdown>
-[**Colors**](style.md#colors)
+[**Colors**](style.md#colors-back)
 
 A class for managing text colors.
 </div>
@@ -58,6 +58,16 @@ A class for managing text colors.
 [**Styles**](style.md#styles_1)
 
 A class for managing text styles.
+</div>
+
+---
+
+<div class="grid" markdown>
+[**AnsiCodes**](style.md#ansicodes)
+
+A classes for managing colors. 
+`Colors` for text colors aka foreground. 
+`Back` for background.
 </div>
 
 ---

--- a/docs/components/style.md
+++ b/docs/components/style.md
@@ -3,46 +3,130 @@
 The **Style** module allows you to customize text styling and colors,
 including in **Outlify** elements.
 
-To view the demo for the **Panel** module use:
+To view the demo for the **Style** module use:
 
 ```sh
 python -m outlify.style
 ```
 
-## `Colors`
-A class for managing text colors.
+## `Colors` / `Back`
 
-### Available fields
+A classes for managing colors.
 
-| Field     |   Value    | Comments                               |
-|-----------|:----------:|----------------------------------------|
-| `black`   | `\033[30m` |
-| `red`     | `\033[31m` |
-| `green`   | `\033[32m` |
-| `yellow`  | `\033[33m` |
-| `blue`    | `\033[34m` |
-| `magenta` | `\033[35m` |
-| `cyan`    | `\033[36m` |
-| `white`   | `\033[37m` |
-| `default` | `\033[39m` |
-| `gray`    | `\033[90m` |
-| `reset`   | `\033[0m`  | reset all styles include colors/styles |
+* `Colors` for text colors aka foreground.
+* `Back` for background.
+
+### Standard color: 8-16 Colors
+
+| Color field | Text color codes | Background color codes | Comments         |
+|-------------|:----------------:|:----------------------:|------------------|
+| `black`     |       `30`       |          `40`          |
+| `red`       |       `31`       |          `41`          |
+| `green`     |       `32`       |          `42`          |
+| `yellow`    |       `33`       |          `43`          |
+| `blue`      |       `34`       |          `44`          |
+| `magenta`   |       `35`       |          `45`          |
+| `cyan`      |       `36`       |          `46`          |
+| `white`     |       `37`       |          `47`          |
+| `gray`      |       `90`       |         `100`          | Bright black     |
+| `crimson`   |       `91`       |         `101`          | Bright red       |
+| `lime`      |       `92`       |         `102`          | Bright green     |
+| `gold`      |       `93`       |         `103`          | Bright yellow    |
+| `skyblue`   |       `94`       |         `104`          | Bright blue      |
+| `violet`    |       `95`       |         `105`          | Bright magenta   |
+| `aqua`      |       `96`       |         `106`          | Bright cyan      |
+| `snow`      |       `97`       |         `107`          | Bright white     |
+| `reset`     |       `39`       |          `39`          | Reset all colors |
 
 ## `Styles`
+
 A class for managing text styles.
 
 ### Available fields
 
-| Fields        |   Value    | Comments                               |
-|---------------|:----------:|----------------------------------------|
-| `bold`        | `\033[1m`  |
-| `dim`         | `\033[2m`  |
-| `italic`      | `\033[3m`  |
-| `underline`   | `\033[4m`  |
-| `crossed_out` | `\033[9m`  |
-| `default`     | `\033[22m` |
-| `reset`       | `\033[0m`  | reset all styles include colors/styles |
+| Style Field / Reset field           | Text style codes | Reset style codes | Description                                                 |
+|-------------------------------------|:----------------:|:-----------------:|-------------------------------------------------------------|
+| `bold` / `reset_bold`               |       `1`        |       `22`        | Makes text bold or brighter (depending on terminal support) |
+| `dim` / `reset_dim`                 |       `2`        |       `22`        | Makes text dim or less intense                              |
+| `italic` / `reset_italic`           |       `3`        |       `23`        | Italic text (not supported in many terminal emulators)      |
+| `underline` / `reset_underline`     |       `4`        |       `24`        | Underlines the text                                         |
+| `blink` / `reset_blink`             |       `5`        |       `25`        | Makes the text blink (deprecated and rarely supported)      |
+| `inverse` / `reset_inverse`         |       `7`        |       `27`        | Inverts foreground and background colors                    |
+| `hidden` / `reset_hidden`           |       `8`        |       `28`        | Hides the text (useful for passwords, visible when copied)  |
+| `crossed_out` / `reset_crossed_out` |       `9`        |       `29`        | Strikes through the text                                    |
+| `reset`                             |       `0`        |                   | Reset all styles include colors/styles                      |
 
+## `AnsiCodes`
+
+This is parent class for `Colors`, `Back`, `Styles`. 
+But it can help you in your customization as well. 
+Just specify the variable name and its value as a code / sequence of codes,
+and it will convert your codes to ansi escape sequences on initialization
+like this:
+
+```python
+from outlify.style import AnsiCodes
+
+class CustomAnsiCodes(AnsiCodes):
+    <name> = <code(s)>
+
+Custom = CustomAnsiCodes()
+```
+
+And use it as a **Outlify** styles.
+
+If you do not have enough standard colors, for example, you want to add
+a branded color of your instrument, then you can use `AnsiCodes`.
+
+* Colors by IDs: [256 Colors](#256-colors) 
+* Colors by RGB: [RGB Colors](#rgb-colors) 
+
+### 256 Colors
+The following escape codes tells the terminal to use the given color ID:
+
+| Codes             | Description                   |
+|-------------------|-------------------------------|
+| `38`, `5`, `{ID}` | Set text color aka foreground |
+| `48`, `5`, `{ID}` | Set background color          |
+
+You can find more information at [ANSI Escape Sequences: 256 Colors](https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797#256-colors)
+
+How to create your own colors by IDs using `AnsiCodes`:
+```python
+from outlify.style import AnsiCodes, Colors
+
+class IDAnsiCodes(AnsiCodes):
+    pink   = [38, 5, 207]
+    orange = [38, 5, 208]
+
+Custom = IDAnsiCodes()
+print(f'{Custom.pink}Colored text{Colors.default}')
+```
+
+### RGB Colors
+
+More modern terminals supports [Truecolor](https://en.wikipedia.org/wiki/Color_depth#True_color_.2824-bit.29) (24-bit RGB), which allows you to set foreground and background colors using RGB.
+
+The following escape codes tells the terminal to use the given RGB color:
+
+| Codes                          | Description                           |
+|:-------------------------------|:--------------------------------------|
+| `38`, `2`, `{r}`, `{g}`, `{b}` | Set text color aka foreground as RGB. |
+| `48`, `2`, `{r}`, `{g}`, `{b}` | Set background color as RGB.          |
+
+You can find more information at [ANSI Escape Sequences: RGB Colors](https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797#rgb-colors)
+
+How to create your own colors by IDs using `AnsiCodes`:
+```python
+from outlify.style import AnsiCodes, Colors
+
+class RGBAnsiCodes(AnsiCodes):
+    pink   = [38, 2, 255, 192, 203]
+    orange = [38, 2, 255, 128, 0]
+
+Custom = RGBAnsiCodes()
+print(f'{Custom.pink}Colored text{Colors.default}')
+```
 
 ## Advanced
 ### Ansi escape sequences

--- a/docs/components/style.md
+++ b/docs/components/style.md
@@ -100,7 +100,7 @@ class IDAnsiCodes(AnsiCodes):
     orange = [38, 5, 208]
 
 Custom = IDAnsiCodes()
-print(f'{Custom.pink}Colored text{Colors.default}')
+print(f'{Custom.pink}Colored text{Colors.reset}')
 ```
 
 ### RGB Colors
@@ -125,7 +125,7 @@ class RGBAnsiCodes(AnsiCodes):
     orange = [38, 2, 255, 128, 0]
 
 Custom = RGBAnsiCodes()
-print(f'{Custom.pink}Colored text{Colors.default}')
+print(f'{Custom.pink}Colored text{Colors.reset}')
 ```
 
 ## Advanced

--- a/outlify/_ansi.py
+++ b/outlify/_ansi.py
@@ -100,9 +100,3 @@ class AnsiStylesCodes(AnsiCodes):
 Colors = AnsiColorsCodes()
 Back = AnsiBackColorsCodes()
 Styles = AnsiStylesCodes()
-
-class CustomAnsiColorsCodes(AnsiCodes):
-    branded = [38, 2, 255, 165, 0]
-
-custom = CustomAnsiColorsCodes()
-print(f'{custom.branded}123')

--- a/outlify/_ansi.py
+++ b/outlify/_ansi.py
@@ -1,7 +1,10 @@
 from typing import Sequence
 
 
-__all__ = ['Colors', 'Back', 'Styles', 'AnsiCodes']
+__all__ = [
+    'Colors', 'Back', 'Styles',
+    'AnsiCodes', 'AnsiColorsCodes', 'AnsiBackColorsCodes', 'AnsiStylesCodes'
+]
 
 
 CSI = '\033['  # Control Sequence Introducer

--- a/outlify/_ansi.py
+++ b/outlify/_ansi.py
@@ -1,7 +1,7 @@
 from typing import Sequence
 
 
-__all__ = ['Colors', 'Styles', 'AnsiCodes']
+__all__ = ['Colors', 'Back', 'Styles', 'AnsiCodes']
 
 
 CSI = '\033['  # Control Sequence Introducer

--- a/outlify/_ansi.py
+++ b/outlify/_ansi.py
@@ -43,9 +43,8 @@ class AnsiColorsCodes(AnsiCodes):
     aqua    = 96
     snow    = 97
 
-    default = 39
-    # reset all styles include colors/styles
-    reset   = 0
+    # reset all colors
+    reset   = 39
 
 
 class AnsiBackColorsCodes(AnsiCodes):
@@ -69,9 +68,8 @@ class AnsiBackColorsCodes(AnsiCodes):
     aqua    = 106
     snow    = 107
 
-    default = 49
-    # reset all styles include colors/styles
-    reset   = 0
+    # reset all colors
+    reset   = 49
 
 
 class AnsiStylesCodes(AnsiCodes):

--- a/outlify/_ansi.py
+++ b/outlify/_ansi.py
@@ -1,3 +1,6 @@
+from typing import Sequence
+
+
 __all__ = ['Colors', 'Styles', 'AnsiCodes']
 
 
@@ -12,14 +15,15 @@ def code_to_ansi(*codes: int) -> str:
 class AnsiCodes:
     def __init__(self):
         for name in (name for name in dir(self) if not name.startswith('_')):
-            setattr(self, name, code_to_ansi(getattr(self, name)))
-
-    @classmethod
-    def get_available_values(cls) -> tuple[str, ...]:
-        return tuple(value for value in dir(cls) if not value.startswith('_'))
+            value = getattr(self, name)
+            if isinstance(value, Sequence):
+                setattr(self, name, code_to_ansi(*value))
+            else:
+                setattr(self, name, code_to_ansi(value))
 
 
 class AnsiColorsCodes(AnsiCodes):
+    # standard colors
     black   = 30
     red     = 31
     green   = 32
@@ -28,22 +32,78 @@ class AnsiColorsCodes(AnsiCodes):
     magenta = 35
     cyan    = 36
     white   = 37
-    default = 39
-    gray    = 90
 
-    reset = 0  # reset all styles include colors/styles
+    # bright colors
+    gray    = 90
+    crimson = 91
+    lime    = 92
+    gold    = 93
+    skyblue = 94
+    violet  = 95
+    aqua    = 96
+    snow    = 97
+
+    default = 39
+    # reset all styles include colors/styles
+    reset   = 0
+
+
+class AnsiBackColorsCodes(AnsiCodes):
+    # standard colors
+    black   = 40
+    red     = 41
+    green   = 42
+    yellow  = 43
+    blue    = 44
+    magenta = 45
+    cyan    = 46
+    white   = 47
+
+    # bright colors
+    gray    = 100
+    crimson = 101
+    lime    = 102
+    gold    = 103
+    skyblue = 104
+    violet  = 105
+    aqua    = 106
+    snow    = 107
+
+    default = 49
+    # reset all styles include colors/styles
+    reset   = 0
 
 
 class AnsiStylesCodes(AnsiCodes):
-    bold        = 1
-    dim         = 2
-    italic      = 3
-    underline   = 4
-    crossed_out = 9
-    default     = 22
+    bold              = 1
+    dim               = 2
+    italic            = 3
+    underline         = 4
+    blink             = 5
+    inverse           = 7
+    hidden            = 8
+    crossed_out       = 9
 
-    reset       = 0  # reset all styles include colors/styles
+    reset_bold        = 22
+    reset_dim         = 22
+    reset_italic      = 23
+    reset_underline   = 24
+    reset_blink       = 25
+    reset_inverse     = 27
+    reset_hidden      = 28
+    reset_crossed_out = 29
+
+    default           = 22
+    # reset all styles include colors/styles
+    reset             = 0
 
 
 Colors = AnsiColorsCodes()
+Back = AnsiBackColorsCodes()
 Styles = AnsiStylesCodes()
+
+class CustomAnsiColorsCodes(AnsiCodes):
+    branded = [38, 2, 255, 165, 0]
+
+custom = CustomAnsiColorsCodes()
+print(f'{custom.branded}123')

--- a/outlify/_ansi.py
+++ b/outlify/_ansi.py
@@ -93,7 +93,6 @@ class AnsiStylesCodes(AnsiCodes):
     reset_hidden      = 28
     reset_crossed_out = 29
 
-    default           = 22
     # reset all styles include colors/styles
     reset             = 0
 

--- a/outlify/style.py
+++ b/outlify/style.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import NamedTuple
 
-from outlify._ansi import Colors, Styles, AnsiCodes  # noqa: F401
+from outlify._ansi import Colors, Back, Styles, AnsiCodes  # noqa: F401
 
 
 class Align(Enum):

--- a/outlify/style.py
+++ b/outlify/style.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import NamedTuple
 
-from outlify._ansi import Colors, Back, Styles, AnsiCodes  # noqa: F401
+from outlify._ansi import Colors, Back, Styles, AnsiCodes, AnsiColorsCodes, AnsiBackColorsCodes, AnsiStylesCodes  # noqa: F401
 
 
 class Align(Enum):

--- a/tests/unit/test_ansi.py
+++ b/tests/unit/test_ansi.py
@@ -1,23 +1,33 @@
 import pytest
 
-from outlify._ansi import Colors, Styles, AnsiCodes
+from outlify._ansi import Colors, Back, Styles, AnsiCodes
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
     'color,result',
     [
-        (Colors.black, '\033[30m'),
-        (Colors.red, '\033[31m'),
-        (Colors.green, '\033[32m'),
-        (Colors.yellow, '\033[33m'),
-        (Colors.blue, '\033[34m'),
+        # standard colors
+        (Colors.black,   '\033[30m'),
+        (Colors.red,     '\033[31m'),
+        (Colors.green,   '\033[32m'),
+        (Colors.yellow,  '\033[33m'),
+        (Colors.blue,    '\033[34m'),
         (Colors.magenta, '\033[35m'),
-        (Colors.cyan, '\033[36m'),
-        (Colors.white, '\033[37m'),
-        (Colors.default, '\033[39m'),
-        (Colors.gray, '\033[90m'),
-        (Colors.reset, '\033[0m'),
+        (Colors.cyan,    '\033[36m'),
+        (Colors.white,   '\033[37m'),
+
+        # bright colors
+        (Colors.gray,    '\033[90m'),
+        (Colors.crimson, '\033[91m'),
+        (Colors.lime,    '\033[92m'),
+        (Colors.gold,    '\033[93m'),
+        (Colors.skyblue, '\033[94m'),
+        (Colors.violet,  '\033[95m'),
+        (Colors.aqua,    '\033[96m'),
+        (Colors.snow,    '\033[97m'),
+
+        (Colors.reset, '\033[39m'),
     ]
 )
 def test_colors(color: AnsiCodes, result: str):
@@ -26,14 +36,59 @@ def test_colors(color: AnsiCodes, result: str):
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
+    'back,result',
+    [
+        # standard colors
+        (Back.black,   '\033[40m'),
+        (Back.red,     '\033[41m'),
+        (Back.green,   '\033[42m'),
+        (Back.yellow,  '\033[43m'),
+        (Back.blue,    '\033[44m'),
+        (Back.magenta, '\033[45m'),
+        (Back.cyan,    '\033[46m'),
+        (Back.white,   '\033[47m'),
+
+        # bright colors
+        (Back.gray,    '\033[100m'),
+        (Back.crimson, '\033[101m'),
+        (Back.lime,    '\033[102m'),
+        (Back.gold,    '\033[103m'),
+        (Back.skyblue, '\033[104m'),
+        (Back.violet,  '\033[105m'),
+        (Back.aqua,    '\033[106m'),
+        (Back.snow,    '\033[107m'),
+
+        (Back.reset, '\033[49m'),
+    ]
+)
+def test_back(back: AnsiCodes, result: str):
+    assert back == result
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
     'style,result',
     [
-        (Styles.bold, '\033[1m'),
-        (Styles.dim, '\033[2m'),
-        (Styles.italic, '\033[3m'),
-        (Styles.underline, '\033[4m'),
+        # styles
+        (Styles.bold,        '\033[1m'),
+        (Styles.dim,         '\033[2m'),
+        (Styles.italic,      '\033[3m'),
+        (Styles.underline,   '\033[4m'),
+        (Styles.blink,       '\033[5m'),
+        (Styles.inverse,     '\033[7m'),
+        (Styles.hidden,      '\033[8m'),
         (Styles.crossed_out, '\033[9m'),
-        (Styles.default, '\033[22m'),
+
+        # reset styles
+        (Styles.reset_bold,        '\033[22m'),
+        (Styles.reset_dim,         '\033[22m'),
+        (Styles.reset_italic,      '\033[23m'),
+        (Styles.reset_underline,   '\033[24m'),
+        (Styles.reset_blink,       '\033[25m'),
+        (Styles.reset_inverse,     '\033[27m'),
+        (Styles.reset_hidden,      '\033[28m'),
+        (Styles.reset_crossed_out, '\033[29m'),
+
         (Styles.reset, '\033[0m'),
     ]
 )


### PR DESCRIPTION
New styles, codes

New instance for background colors

breaking changes:
codes for defaults now is `reset`

Explain:
reset for `Colors` - reset all foreground colors **(not all styles)**
reset for `Back` - reset all background colors  **(not all styles)**
reset for `Styles` - reset all styles/colors